### PR TITLE
Allow queue prefix to be configured/ignore queue already exist error

### DIFF
--- a/pubsub/kombu_transport.py
+++ b/pubsub/kombu_transport.py
@@ -106,14 +106,18 @@ class Channel(virtual.Channel):
         topic_path = self.topic_path(queue_name)
         try:
             self._publisher.create_topic(topic_path)
-        except Exception:
-            log.warn('Unable to create topic.')
+        except exceptions.AlreadyExists:
+            pass
+        except:
+            log.warn('Unable to create topic.', exc_info=True)
 
         subscription_path = self.subscription_path(queue_name)
         try:
             self._subscriber.create_subscription(subscription_path, topic_path)
-        except Exception:
-            log.warn('Unable to create subscription.')
+        except exceptions.AlreadyExists:
+            pass
+        except:
+            log.warn('Unable to create subscription.', exc_info=True)
 
     '''
     def queue_bind(self, queue, exchange, routing_key, **kwargs):


### PR DESCRIPTION
Sorry for submitting both in the same PR. You can review each commit separately and cherry-pick if needed.

I added two things:

- Queue prefix can be configured with 'prefix' transport option, defaulting to empty string. In my use case I use several queues so it would be useful if I could see which are managed by Celery in the cloud console.
- Topic/subscription AlreadyExists error are no longer being logged. Previously this would log "Unable to create topic.".